### PR TITLE
Add R examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,15 @@
 This repository exists to illustrate some CI examples as simply as possible. 
 See `.github/worklows` folder for the CI workflows.
 
+## Community examples
+
+### R projects
+
+The [r-lib/actions](https://github.com/r-lib/actions/tree/master/examples) repo
+contains examples of GitHub Actions workflows for testing R packages, building
+pkgdown sites, and more. You can copy these into your project, or use
+[helpers from usethis](https://ropenscilabs.github.io/actions_sandbox/packageci.html)
+to set them up for you.
+
 ## Contributions
 Contributions are welcome! Please fork this repositry and submit a pull request.


### PR DESCRIPTION
Adds a link to existing examples of github actions workflows for R projects and how to use them